### PR TITLE
bugfix/use-getclass-io-5.5-class-keyword use get_class() instead of :…

### DIFF
--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -9,8 +9,12 @@ use PHPUnit_Framework_Assert as Assert;
 class ClientTest extends PHPUnit_Framework_TestCase
 {
 
-    /** @var  Client */
+    /** @var  Client $client */
     private $client;
+    /** @var  string $clientId */
+    private $clientId;
+    /** @var  string $clientSecret */
+    private $clientSecret;
 
     /**
      * Set up test suite
@@ -19,15 +23,27 @@ class ClientTest extends PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $clientId = mt_rand();
-        $clientSecret = mt_rand();
+        $this->clientId = mt_rand();
+        $this->clientSecret = mt_rand();
 
-        $this->client = new Client($clientId, $clientSecret);
+        $this->client = new Client($this->clientId, $this->clientSecret);
     }
 
+    /**
+     * Test instantiation of the Client with client credentials.
+     */
     public function testClientInstantiation()
     {
-        Assert::assertInstanceOf(Client::class, $this->client);
+        Assert::assertInstanceOf('Beslist\OrderAPI\Client', $this->client);
+        $reflectionClass = new \ReflectionClass($this->client);
+        $reflectionClientId = $reflectionClass->getProperty('clientId');
+        $reflectionClientSecret = $reflectionClass->getProperty('clientSecret');
+
+        $reflectionClientId->setAccessible(true);
+        $reflectionClientSecret->setAccessible(true);
+
+        Assert::assertEquals($this->clientId, $reflectionClientId->getValue($this->client));
+        Assert::assertEquals($this->clientSecret, $reflectionClientSecret->getValue($this->client));
     }
 
 }


### PR DESCRIPTION
bugfix/use-getclass-io-5.5-class-keyword use get_class() instead of ::class for php 5.4